### PR TITLE
Fix error handling and sample app crash

### DIFF
--- a/appsDiscovery/src/main/java/org/kinecosystem/appsdiscovery/TransferIntent.java
+++ b/appsDiscovery/src/main/java/org/kinecosystem/appsdiscovery/TransferIntent.java
@@ -1,0 +1,8 @@
+package org.kinecosystem.appsdiscovery;
+
+public class TransferIntent {
+    public static final int REQUEST_CODE = 77;
+    public static final String EXTRA_SOURCE_APP_NAME = "EXTRA_SOURCE_APP_NAME";
+    public static final String  EXTRA_HAS_ERROR = "EXTRA_HAS_ERROR";
+    public static final String EXTRA_ERROR_MESSAGE = "EXTRA_ERROR_MESSAGE";
+}

--- a/appsDiscovery/src/main/java/org/kinecosystem/appsdiscovery/receiver/manager/AccountInfoResponder.java
+++ b/appsDiscovery/src/main/java/org/kinecosystem/appsdiscovery/receiver/manager/AccountInfoResponder.java
@@ -6,6 +6,8 @@ import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.v4.content.FileProvider;
 
+import org.kinecosystem.appsdiscovery.TransferIntent;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -15,7 +17,6 @@ import java.io.IOException;
 
 
 public class AccountInfoResponder implements IAccountInfoResponder {
-    private static final String EXTRA_HAS_ERROR = "EXTRA_HAS_ERROR";
     private static final String FILE_NAME = "accountInfo.txt";
     private static final String FILE_PROVIDER_NAME = "KinTransferAccountInfoFileProvider";
     private static final String FILE_PROVIDER_DIR_NAME = "kintransfer_account_info";
@@ -60,14 +61,14 @@ public class AccountInfoResponder implements IAccountInfoResponder {
     }
 
     //Can be called anytime (before init returns), when there is some error
-    public void respondError() {
-        respondCancel(true);
+    public void respondError(String errorMessage) {
+        respondCancel(errorMessage);
     }
 
 
     //Can be called anytime (before init returns), when user decline transfer
     public void respondCancel() {
-        respondCancel(false);
+        respondCancel(null);
     }
 
     //Can be called only after init returns true, hence file is not null
@@ -82,10 +83,11 @@ public class AccountInfoResponder implements IAccountInfoResponder {
         }
     }
 
-    private void respondCancel(boolean hasError) {
+    private void respondCancel(String errorMessage) {
         Intent intent = new Intent();
-        if (hasError) {
-            intent.putExtra(EXTRA_HAS_ERROR, hasError);
+        if (errorMessage != null) {
+            intent.putExtra(TransferIntent.EXTRA_HAS_ERROR, true);
+            intent.putExtra(TransferIntent.EXTRA_ERROR_MESSAGE, errorMessage);
         }
         if (activity != null) {
             activity.setResult(Activity.RESULT_CANCELED, intent);

--- a/appsDiscovery/src/main/java/org/kinecosystem/appsdiscovery/receiver/manager/IAccountInfoResponder.java
+++ b/appsDiscovery/src/main/java/org/kinecosystem/appsdiscovery/receiver/manager/IAccountInfoResponder.java
@@ -6,7 +6,7 @@ public interface IAccountInfoResponder {
 
     boolean init(@NonNull final String publicAddress);
 
-    void respondError();
+    void respondError(String errorMessage);
 
     void respondCancel();
 

--- a/appsDiscovery/src/main/java/org/kinecosystem/appsdiscovery/sender/discovery/presenter/AppInfoPresenter.kt
+++ b/appsDiscovery/src/main/java/org/kinecosystem/appsdiscovery/sender/discovery/presenter/AppInfoPresenter.kt
@@ -94,10 +94,12 @@ class AppInfoPresenter(private val appName: String?, private val repository: Dis
     private fun parsePublicAddressData(requestCode: Int, resultCode: Int, intent: Intent?) {
         transferManager.processResponse(requestCode, resultCode, intent, object : TransferManager.AccountInfoResponseListener {
             override fun onCancel() {
+                Log.d("AppInfoPresenter", "Operation cancelled, no public address received")
                 view?.onRequestReceiverPublicAddressCanceled()
             }
 
             override fun onError(error: String) {
+                Log.d("AppInfoPresenter", "Error retrieving public address, error message "+error)
                 view?.onRequestReceiverPublicAddressError(RequestReceiverPublicAddressError.BadDataReceived)
 
             }

--- a/appsDiscovery/src/main/java/org/kinecosystem/appsdiscovery/sender/transfer/TransferManager.kt
+++ b/appsDiscovery/src/main/java/org/kinecosystem/appsdiscovery/sender/transfer/TransferManager.kt
@@ -115,7 +115,10 @@ class TransferManager(var activity: Activity?) {
     private fun processResultCanceled(intent: Intent?, accountInfoResponseListener: AccountInfoResponseListener) {
         if (intent != null) {
             if (intent.getBooleanExtra(TransferIntent.EXTRA_HAS_ERROR, false)) {
-                accountInfoResponseListener.onError(intent.getStringExtra(TransferIntent.EXTRA_ERROR_MESSAGE))
+                val errorMessage = if (intent.hasExtra(TransferIntent.EXTRA_ERROR_MESSAGE)) {
+                    intent.getStringExtra(TransferIntent.EXTRA_ERROR_MESSAGE)
+                } else ""
+                accountInfoResponseListener.onError(errorMessage)
             } else {
                 accountInfoResponseListener.onCancel()
             }

--- a/appsDiscovery/src/main/java/org/kinecosystem/appsdiscovery/sender/transfer/TransferManager.kt
+++ b/appsDiscovery/src/main/java/org/kinecosystem/appsdiscovery/sender/transfer/TransferManager.kt
@@ -3,15 +3,13 @@ package org.kinecosystem.appsdiscovery.sender.transfer
 import android.app.Activity
 import android.content.ComponentName
 import android.content.Intent
+import android.util.Log
+import org.kinecosystem.appsdiscovery.TransferIntent
 import java.io.BufferedReader
 import java.io.InputStreamReader
 
 
 class TransferManager(var activity: Activity?) {
-    private val REQUEST_CODE = 77
-    private val EXTRA_SOURCE_APP_NAME = "EXTRA_SOURCE_APP_NAME"
-    private val EXTRA_HAS_ERROR = "EXTRA_HAS_ERROR"
-    private val EXTRA_ERROR_MESSAGE = "EXTRA_ERROR_MESSAGE"
 
     interface AccountInfoResponseListener {
         fun onCancel()
@@ -40,9 +38,9 @@ class TransferManager(var activity: Activity?) {
                 val exported = resolveInfos[0].activityInfo.exported
                 if (exported) {
                     val appName = it.applicationInfo.loadLabel(packageManager).toString()
-                    intent.putExtra(EXTRA_SOURCE_APP_NAME, appName)
+                    intent.putExtra(TransferIntent.EXTRA_SOURCE_APP_NAME, appName)
                     try {
-                        it.startActivityForResult(intent, REQUEST_CODE)
+                        it.startActivityForResult(intent, TransferIntent.REQUEST_CODE)
                     } catch (e: Exception) {
                         return false
                     }
@@ -68,7 +66,7 @@ class TransferManager(var activity: Activity?) {
             intent: Intent?,
             accountInfoResponseListener: AccountInfoResponseListener
     ) {
-        if (requestCode == REQUEST_CODE) {
+        if (requestCode == TransferIntent.REQUEST_CODE) {
             if (intent != null) {
                 if (resultCode == Activity.RESULT_OK) {
                     processResultOk(intent, accountInfoResponseListener)
@@ -116,8 +114,8 @@ class TransferManager(var activity: Activity?) {
 
     private fun processResultCanceled(intent: Intent?, accountInfoResponseListener: AccountInfoResponseListener) {
         if (intent != null) {
-            if (intent.getBooleanExtra(EXTRA_HAS_ERROR, false)) {
-                accountInfoResponseListener.onError(intent.getStringExtra(EXTRA_ERROR_MESSAGE))
+            if (intent.getBooleanExtra(TransferIntent.EXTRA_HAS_ERROR, false)) {
+                accountInfoResponseListener.onError(intent.getStringExtra(TransferIntent.EXTRA_ERROR_MESSAGE))
             } else {
                 accountInfoResponseListener.onCancel()
             }

--- a/sampleReceiverApp/src/main/java/org/kinecosystem/sampleReceiverApp/AccountInfoActivity.java
+++ b/sampleReceiverApp/src/main/java/org/kinecosystem/sampleReceiverApp/AccountInfoActivity.java
@@ -9,7 +9,7 @@ public class AccountInfoActivity extends AccountInfoActivityBase {
     @Override
     public String getPublicAddress() {
         SampleWallet sampleWallet = ((ReceiverApplication)getApplicationContext()).getSampleWallet();
-        if (sampleWallet != null && sampleWallet.hasAccount() ) {
+        if (sampleWallet != null && sampleWallet.hasActiveAccount() ) {
             return sampleWallet.getAccount().getPublicAddress();
         }
         return null;

--- a/sampleReceiverApp/src/main/java/org/kinecosystem/sampleReceiverApp/ReceiverApplication.java
+++ b/sampleReceiverApp/src/main/java/org/kinecosystem/sampleReceiverApp/ReceiverApplication.java
@@ -6,11 +6,13 @@ import android.app.Application;
 import org.kinecosystem.sampleReceiverApp.sampleWallet.SampleWallet;
 
 public class ReceiverApplication extends Application {
-
+    private static final String APP_ID = "recv";
     private SampleWallet sampleWallet;
 
-    public void setSampleWallet(SampleWallet wallet){
-        sampleWallet = wallet;
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        sampleWallet = new SampleWallet(this, APP_ID);
     }
 
     public SampleWallet getSampleWallet(){

--- a/sampleReceiverApp/src/main/java/org/kinecosystem/sampleReceiverApp/ReceiverMainActivity.java
+++ b/sampleReceiverApp/src/main/java/org/kinecosystem/sampleReceiverApp/ReceiverMainActivity.java
@@ -1,9 +1,8 @@
 package org.kinecosystem.sampleReceiverApp;
 
-import android.os.PersistableBundle;
+import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
-import android.os.Bundle;
 import android.widget.TextView;
 
 import org.kinecosystem.sampleReceiverApp.sampleWallet.OnBoarding;
@@ -14,8 +13,6 @@ import kin.utils.Request;
 import kin.utils.ResultCallback;
 
 public class ReceiverMainActivity extends AppCompatActivity {
-    private static final String APP_ID = "recv";
-    private SampleWallet sampleWallet;
     private boolean activityCreated = false;
 
     @Override
@@ -23,19 +20,19 @@ public class ReceiverMainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        sampleWallet = new SampleWallet(this, APP_ID);
-        ((ReceiverApplication) getApplicationContext()).setSampleWallet(sampleWallet);
-
         activityCreated = true;
 
         initAccountAndViews();
     }
 
+    private SampleWallet getSampleWallet() {
+        return ((ReceiverApplication) getApplicationContext()).getSampleWallet();
+    }
 
     private void initAccountAndViews() {
-
+        SampleWallet sampleWallet = getSampleWallet();
         TextView addressView = findViewById((R.id.publicAddressView));
-        if (sampleWallet.hasAccount()) {
+        if (sampleWallet.hasActiveAccount()) {
             String text = getString(R.string.public_address, sampleWallet.getAccount().getPublicAddress());
             addressView.setText(text);
             initBalance();
@@ -71,7 +68,7 @@ public class ReceiverMainActivity extends AppCompatActivity {
 
     private void updateBalance(TextView balanceView) {
         balanceView.setText(R.string.update_balance);
-        Request<Balance> balanceRequest = sampleWallet.getAccount().getBalance();
+        Request<Balance> balanceRequest = getSampleWallet().getAccount().getBalance();
         balanceRequest.run(new ResultCallback<Balance>() {
             @Override
             public void onResult(Balance result) {

--- a/sampleReceiverApp/src/main/java/org/kinecosystem/sampleReceiverApp/sampleWallet/SampleWallet.java
+++ b/sampleReceiverApp/src/main/java/org/kinecosystem/sampleReceiverApp/sampleWallet/SampleWallet.java
@@ -2,6 +2,7 @@ package org.kinecosystem.sampleReceiverApp.sampleWallet;
 
 
 import android.content.Context;
+import android.content.SharedPreferences;
 
 import kin.sdk.Environment;
 import kin.sdk.KinAccount;
@@ -14,8 +15,10 @@ public class SampleWallet {
 
     private KinAccount account;
     private KinClient kinClient;
+    private SharedPreferences sharedPreferences;
 
     public SampleWallet(Context context, String appId) {
+        sharedPreferences = context.getSharedPreferences("SampleReceiver", Context.MODE_PRIVATE);
         kinClient = new KinClient(context,
                 new Environment(SDK_TEST_NETWORK_URL, SDK_TEST_NETWORK_ID), appId);
         if (kinClient.hasAccount()) {
@@ -23,26 +26,43 @@ public class SampleWallet {
         }
     }
 
-    public boolean hasAccount() {
-        return account != null;
+    public boolean hasActiveAccount() {
+        return account != null && isAccountCreated();
     }
 
     public KinAccount getAccount() {
         return account;
     }
 
-    public KinClient getKinClient() {
-        return kinClient;
-    }
-    
     public void createAccount(OnBoarding.Callbacks callbacks) {
         try {
             account = kinClient.addAccount();
             OnBoarding onboarding = new OnBoarding();
-            onboarding.onBoard(account, callbacks);
+            onboarding.onBoard(account, new OnBoarding.Callbacks() {
+                @Override
+                public void onSuccess() {
+                    setAccountCreated();
+                    callbacks.onSuccess();
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    callbacks.onFailure(e);
+                }
+            });
         } catch (CreateAccountException e) {
             e.printStackTrace();
         }
 
+    }
+
+    private boolean isAccountCreated() {
+        return sharedPreferences.getBoolean("account_created", false);
+    }
+
+    private void setAccountCreated() {
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+        editor.putBoolean("account_created", true);
+        editor.apply();
     }
 }

--- a/sampleSenderApp/src/main/java/org/kinecosystem/sampleSenderApp/SendKinService.java
+++ b/sampleSenderApp/src/main/java/org/kinecosystem/sampleSenderApp/SendKinService.java
@@ -18,7 +18,7 @@ public class SendKinService extends SendKinServiceBase {
         SampleWallet sampleWallet = ((SenderApplication) getApplicationContext()).getSampleWallet();
         String sourceAddress = "None";
 
-        if (!sampleWallet.hasAccount()) {
+        if (!sampleWallet.hasActiveAccount()) {
 
             throw new KinTransferException(sourceAddress, "Cannot transfer Kin. Account not initialized");
         }
@@ -51,7 +51,7 @@ public class SendKinService extends SendKinServiceBase {
 
         SampleWallet sampleWallet = ((SenderApplication) getApplicationContext()).getSampleWallet();
 
-        if (!sampleWallet.hasAccount()) {
+        if (!sampleWallet.hasActiveAccount()) {
 
             throw new BalanceException("Cannot retrieve Kin balance. Account not initialized");
         }

--- a/sampleSenderApp/src/main/java/org/kinecosystem/sampleSenderApp/SenderApplication.java
+++ b/sampleSenderApp/src/main/java/org/kinecosystem/sampleSenderApp/SenderApplication.java
@@ -6,11 +6,13 @@ import android.app.Application;
 import org.kinecosystem.sampleSenderApp.sampleWallet.SampleWallet;
 
 public class SenderApplication extends Application {
-
+    private static final String APP_ID = "sndr";
     private SampleWallet sampleWallet;
 
-    public void setSampleWallet(SampleWallet wallet){
-        sampleWallet = wallet;
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        sampleWallet = new SampleWallet(this, APP_ID);
     }
 
     public SampleWallet getSampleWallet(){

--- a/sampleSenderApp/src/main/java/org/kinecosystem/sampleSenderApp/SenderMainActivity.java
+++ b/sampleSenderApp/src/main/java/org/kinecosystem/sampleSenderApp/SenderMainActivity.java
@@ -14,8 +14,6 @@ import kin.utils.Request;
 import kin.utils.ResultCallback;
 
 public class SenderMainActivity extends AppCompatActivity {
-    private static final String APP_ID = "send";
-    SampleWallet sampleWallet;
     boolean activityCreated = false;
 
     @Override
@@ -28,30 +26,30 @@ public class SenderMainActivity extends AppCompatActivity {
             dialog.show();
         });
 
-        sampleWallet = new SampleWallet(this, APP_ID);
-        ((SenderApplication) getApplicationContext()).setSampleWallet(sampleWallet);
-
         activityCreated = true;
 
         initAccountAndViews();
     }
 
+    private SampleWallet getSampleWallet() {
+        return ((SenderApplication) getApplicationContext()).getSampleWallet();
+    }
 
     private void initAccountAndViews() {
-
-        TextView paddressView = findViewById((R.id.publicAddressView));
-        if (sampleWallet.hasAccount()) {
+        SampleWallet sampleWallet = getSampleWallet();
+        TextView addressView = findViewById((R.id.publicAddressView));
+        if (sampleWallet.hasActiveAccount()) {
             String text = getString(R.string.public_address, sampleWallet.getAccount().getPublicAddress());
-            paddressView.setText(text);
+            addressView.setText(text);
             initBalance();
         } else {
-            paddressView.setText(R.string.create_wallet);
+            addressView.setText(R.string.create_wallet);
             sampleWallet.createAccount(new OnBoarding.Callbacks() {
                 @Override
                 public void onSuccess() {
                     if (activityCreated) {
                         String text = getString(R.string.public_address, sampleWallet.getAccount().getPublicAddress());
-                        paddressView.setText(text);
+                        addressView.setText(text);
                         initBalance();
                     }
                 }
@@ -59,7 +57,7 @@ public class SenderMainActivity extends AppCompatActivity {
                 @Override
                 public void onFailure(Exception e) {
                     if (activityCreated) {
-                        paddressView.setText(R.string.create_wallet_error);
+                        addressView.setText(R.string.create_wallet_error);
                     }
                 }
             });
@@ -76,7 +74,7 @@ public class SenderMainActivity extends AppCompatActivity {
 
     private void updateBalance(TextView balanceView) {
         balanceView.setText(R.string.update_balance);
-        Request<Balance> balanceRequest = sampleWallet.getAccount().getBalance();
+        Request<Balance> balanceRequest = getSampleWallet().getAccount().getBalance();
         balanceRequest.run(new ResultCallback<Balance>() {
             @Override
             public void onResult(Balance result) {


### PR DESCRIPTION
1. when there is an error on the receiver application return an error message
(not just boolean)

2. Don't crash if there is indication that there is an error but no error message 

3. In the sample apps, make sure wallet is initialised when application starts
(not when activity starts) and store whether the account has been actually created
in shared preferences.

